### PR TITLE
Debug android app launch crash

### DIFF
--- a/app/src/main/java/com/listen/app/perf/PerformanceMonitor.kt
+++ b/app/src/main/java/com/listen/app/perf/PerformanceMonitor.kt
@@ -73,10 +73,12 @@ class PerformanceMonitor(private val context: Context) {
 
     private fun readBatteryInfo(): BatterySnapshot {
         return try {
-            val intent: Intent? = context.registerReceiver(
-                null,
-                IntentFilter(Intent.ACTION_BATTERY_CHANGED)
-            )
+            val intent: Intent? = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+                context.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED), Context.RECEIVER_NOT_EXPORTED)
+            } else {
+                @Suppress("DEPRECATION")
+                context.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+            }
             val level = intent?.getIntExtra(BatteryManager.EXTRA_LEVEL, -1) ?: -1
             val scale = intent?.getIntExtra(BatteryManager.EXTRA_SCALE, -1) ?: -1
             val status = intent?.getIntExtra(BatteryManager.EXTRA_STATUS, -1) ?: -1

--- a/app/src/main/java/com/listen/app/ui/MainActivity.kt
+++ b/app/src/main/java/com/listen/app/ui/MainActivity.kt
@@ -87,7 +87,19 @@ class MainActivity : AppCompatActivity() {
     
     override fun onResume() {
         super.onResume()
-        registerReceiver(statusReceiver, IntentFilter(ListenForegroundService.ACTION_RECORDING_STATUS))
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+            registerReceiver(
+                statusReceiver,
+                IntentFilter(ListenForegroundService.ACTION_RECORDING_STATUS),
+                Context.RECEIVER_NOT_EXPORTED
+            )
+        } else {
+            @Suppress("DEPRECATION")
+            registerReceiver(
+                statusReceiver,
+                IntentFilter(ListenForegroundService.ACTION_RECORDING_STATUS)
+            )
+        }
         updateUI()
     }
     


### PR DESCRIPTION
Update dynamic broadcast receiver registrations to prevent Android 13+ launch crashes.

On Android 13 (API 33) and higher, dynamically registered broadcast receivers must specify an export behavior (e.g., `RECEIVER_NOT_EXPORTED`) to avoid a `SecurityException` at runtime. This change adds the necessary flags to `MainActivity` and `PerformanceMonitor` to ensure compatibility and prevent app crashes on newer Android versions.

---
<a href="https://cursor.com/background-agent?bcId=bc-dafa955b-9a20-4a00-b473-d53df5ec576e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dafa955b-9a20-4a00-b473-d53df5ec576e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

