### PR TITLE
Fix ambiguous service status indicator

### DIFF
--- a/app/src/main/java/com/listen/app/ui/MainActivity.kt
+++ b/app/src/main/java/com/listen/app/ui/MainActivity.kt
@@ -221,6 +221,12 @@ class MainActivity : AppCompatActivity() {
                     isServiceEnabled -> getString(R.string.status_service_starting)
                     else -> getString(R.string.status_service_stopped)
                 }
+                val serviceColorRes = when {
+                    isServiceActuallyRunning -> R.color.status_running_green
+                    isServiceEnabled -> R.color.status_starting_orange
+                    else -> R.color.stopped_gray
+                }
+                binding.tvServiceStatus.setTextColor(ContextCompat.getColor(this@MainActivity, serviceColorRes))
                 
                 // Update button text based on settings (what user wants)
                 binding.btnStartStop.text = if (isServiceEnabled) {
@@ -255,10 +261,12 @@ class MainActivity : AppCompatActivity() {
         val minutes = elapsedMs / 60000
         val seconds = (elapsedMs % 60000) / 1000
         binding.tvRecordingStatus.text = if (isRecording) {
-            getString(R.string.status_recording) + "  ${minutes}:${String.format("%02d", seconds)}"
+            getString(R.string.label_recording) + ":  ${minutes}:${String.format("%02d", seconds)}"
         } else {
-            getString(R.string.status_stopped)
+            getString(R.string.label_recording) + ": " + getString(R.string.status_stopped)
         }
+        val recordingColorRes = if (isRecording) R.color.recording_red else R.color.stopped_gray
+        binding.tvRecordingStatus.setTextColor(ContextCompat.getColor(this, recordingColorRes))
         
         // Update service status to show it's actually running
         val isServiceActuallyRunning = isServiceActuallyRunning()

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -37,7 +37,7 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Service Status"
+                android:text="@string/section_status"
                 android:textSize="18sp"
                 android:textStyle="bold"
                 android:textColor="@color/text_primary" />
@@ -56,7 +56,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="4dp"
-                android:text="@string/status_stopped"
+                android:text="@string/default_recording_status"
                 android:textSize="16sp"
                 android:textColor="@color/text_secondary" />
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -10,6 +10,8 @@
     
     <!-- App specific colors -->
     <color name="recording_red">#FFE53935</color>
+    <color name="status_running_green">#FF4CAF50</color>
+    <color name="status_starting_orange">#FFFFC107</color>
     <color name="stopped_gray">#FF757575</color>
     <color name="background_light">#FFF5F5F5</color>
     <color name="text_primary">#FF212121</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,9 @@
     <string name="status_service_running">Service Running</string>
     <string name="status_service_stopped">Service Stopped</string>
     <string name="status_service_starting">Service Starting...</string>
+    <string name="section_status">Status</string>
+    <string name="label_recording">Recording</string>
+    <string name="default_recording_status">Recording: Stopped</string>
     
     <!-- Storage -->
     <string name="storage_usage">Storage Usage</string>


### PR DESCRIPTION
Add distinct labels and color indicators to service and recording status to resolve UI ambiguity.

---
<a href="https://cursor.com/background-agent?bcId=bc-8acbd451-65e9-4597-baa2-3e73c67bc547">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8acbd451-65e9-4597-baa2-3e73c67bc547">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

