### PR TITLE
Implement auto segment length for music gaps

### DIFF
--- a/app/src/main/java/com/listen/app/audio/AudioRecorderService.kt
+++ b/app/src/main/java/com/listen/app/audio/AudioRecorderService.kt
@@ -172,6 +172,15 @@ class AudioRecorderService(
         }
     }
     
+    /** Get current max amplitude (0..32767). Returns 0 if unavailable. */
+    fun getMaxAmplitude(): Int {
+        return try {
+            mediaRecorder?.maxAmplitude ?: 0
+        } catch (_: Exception) {
+            0
+        }
+    }
+    
     /** Get current segment file */
     fun getCurrentSegmentFile(): File? = currentSegmentFile
     

--- a/app/src/main/java/com/listen/app/service/ListenForegroundService.kt
+++ b/app/src/main/java/com/listen/app/service/ListenForegroundService.kt
@@ -85,6 +85,13 @@ class ListenForegroundService : Service() {
         // Commands
         const val ACTION_UPDATE_SETTINGS = "com.listen.app.ACTION_UPDATE_SETTINGS"
         
+        // Auto music mode heuristics
+        private const val AUTO_MUSIC_POLL_INTERVAL_MS = 100L
+        private const val AUTO_MUSIC_SILENCE_MIN_MS = 1200L
+        private const val AUTO_MUSIC_MAX_EXTRA_WAIT_MS = 180_000L // 3 minutes after target
+        private const val AUTO_MUSIC_MIN_THRESHOLD = 800
+        private const val AUTO_MUSIC_RELATIVE_SILENCE_FACTOR = 0.35
+        
         /** Start the service */
         fun start(context: Context) {
             val intent = Intent(context, ListenForegroundService::class.java)
@@ -314,14 +321,52 @@ class ListenForegroundService : Service() {
         rotationJobActive = true
         serviceScope.launch {
             while (isActive && isServiceRunning) {
-                val segmentDuration = settings.segmentDurationSeconds.toLong().coerceAtLeast(1L)
-                delay(segmentDuration * 1000L)
                 try {
-                    val before = System.currentTimeMillis()
-                    audioRecorder.rotateSegment()
-                    val after = System.currentTimeMillis()
-                    performanceMonitor?.recordSegmentRotation(after - before)
-                    broadcastStatus()
+                    if (!settings.autoMusicModeEnabled) {
+                        val segmentDuration = settings.segmentDurationSeconds.toLong().coerceAtLeast(1L)
+                        delay(segmentDuration * 1000L)
+                        val before = System.currentTimeMillis()
+                        audioRecorder.rotateSegment()
+                        val after = System.currentTimeMillis()
+                        performanceMonitor?.recordSegmentRotation(after - before)
+                        broadcastStatus()
+                    } else {
+                        val targetMs = SettingsManager.AUTO_MUSIC_TARGET_SECONDS * 1000L
+                        // Wait until we reach at least the target duration
+                        while (isActive && isServiceRunning && audioRecorder.getCurrentRecordingDuration() < targetMs) {
+                            delay(250L)
+                            if (!settings.autoMusicModeEnabled) break
+                        }
+                        if (!settings.autoMusicModeEnabled) {
+                            // Mode toggled off; restart loop to use fixed scheduler path
+                            continue
+                        }
+                        // After target, look for a silence window
+                        var emaAmplitude = 0.0
+                        var consecutiveSilenceMs = 0L
+                        val maxSegmentMs = targetMs + AUTO_MUSIC_MAX_EXTRA_WAIT_MS
+                        while (isActive && isServiceRunning && audioRecorder.getCurrentRecordingDuration() < maxSegmentMs) {
+                            val amp = audioRecorder.getMaxAmplitude().coerceAtLeast(0)
+                            // Exponential moving average to adapt threshold
+                            emaAmplitude = if (emaAmplitude == 0.0) amp.toDouble() else (0.9 * emaAmplitude + 0.1 * amp)
+                            val dynamicThreshold = maxOf(AUTO_MUSIC_MIN_THRESHOLD.toDouble(), emaAmplitude * AUTO_MUSIC_RELATIVE_SILENCE_FACTOR).toInt()
+                            if (amp < dynamicThreshold) {
+                                consecutiveSilenceMs += AUTO_MUSIC_POLL_INTERVAL_MS
+                                if (consecutiveSilenceMs >= AUTO_MUSIC_SILENCE_MIN_MS) {
+                                    break
+                                }
+                            } else {
+                                consecutiveSilenceMs = 0L
+                            }
+                            delay(AUTO_MUSIC_POLL_INTERVAL_MS)
+                            if (!settings.autoMusicModeEnabled) break
+                        }
+                        val before = System.currentTimeMillis()
+                        audioRecorder.rotateSegment()
+                        val after = System.currentTimeMillis()
+                        performanceMonitor?.recordSegmentRotation(after - before)
+                        broadcastStatus()
+                    }
                 } catch (e: Exception) {
                     AppLog.e(TAG, "Error rotating segment", e)
                 }

--- a/app/src/main/java/com/listen/app/settings/SettingsManager.kt
+++ b/app/src/main/java/com/listen/app/settings/SettingsManager.kt
@@ -23,6 +23,11 @@ class SettingsManager(context: Context) {
         get() = prefs.getInt(KEY_SEGMENT_DURATION, DEFAULT_SEGMENT_DURATION)
         set(value) = prefs.edit { putInt(KEY_SEGMENT_DURATION, value) }
     
+    /** Whether auto music mode is enabled */
+    var autoMusicModeEnabled: Boolean
+        get() = prefs.getBoolean(KEY_AUTO_MUSIC_MODE, false)
+        set(value) = prefs.edit { putBoolean(KEY_AUTO_MUSIC_MODE, value) }
+    
     /** Retention period in minutes */
     var retentionPeriodMinutes: Int
         get() = prefs.getInt(KEY_RETENTION_PERIOD, DEFAULT_RETENTION_PERIOD)
@@ -70,8 +75,9 @@ class SettingsManager(context: Context) {
     
     /** Calculate total storage usage for current settings */
     fun calculateStorageUsage(): Long {
-        val segmentSizeBytes = (audioBitrate.toLong() * 1000 * segmentDurationSeconds) / 8
-        val segmentsCount = (retentionPeriodMinutes * 60) / segmentDurationSeconds
+        val segmentSeconds = if (autoMusicModeEnabled) AUTO_MUSIC_TARGET_SECONDS else segmentDurationSeconds
+        val segmentSizeBytes = (audioBitrate.toLong() * 1000 * segmentSeconds) / 8
+        val segmentsCount = (retentionPeriodMinutes * 60) / segmentSeconds
         return segmentSizeBytes * segmentsCount
     }
     
@@ -120,6 +126,7 @@ class SettingsManager(context: Context) {
         // Keys
         private const val KEY_SERVICE_ENABLED = "service_enabled"
         private const val KEY_SEGMENT_DURATION = "segment_duration"
+        private const val KEY_AUTO_MUSIC_MODE = "auto_music_mode"
         private const val KEY_RETENTION_PERIOD = "retention_period"
         private const val KEY_AUDIO_BITRATE = "audio_bitrate"
         private const val KEY_AUDIO_SAMPLE_RATE = "audio_sample_rate"
@@ -137,5 +144,6 @@ class SettingsManager(context: Context) {
         const val DEFAULT_AUDIO_BITRATE = 32 // 32 kbps
         const val DEFAULT_AUDIO_SAMPLE_RATE = 16000 // 16 kHz
         const val DEFAULT_MAX_STORAGE = 100 // 100 MB
+        const val AUTO_MUSIC_TARGET_SECONDS = 120 // ~2 minutes
     }
 } 

--- a/app/src/main/java/com/listen/app/ui/SettingsActivity.kt
+++ b/app/src/main/java/com/listen/app/ui/SettingsActivity.kt
@@ -1,6 +1,7 @@
 package com.listen.app.ui
 
 import android.os.Bundle
+import android.text.InputType
 import android.widget.Button
 import android.widget.EditText
 import android.widget.Switch
@@ -25,6 +26,7 @@ class SettingsActivity : AppCompatActivity() {
 		val swAutoStart: Switch = findViewById(R.id.sw_auto_start)
 		val swPowerSaving: Switch = findViewById(R.id.sw_power_saving)
 		val swAdaptive: Switch = findViewById(R.id.sw_adaptive)
+		val swAutoMusic: Switch = findViewById(R.id.sw_auto_music)
 		val btnSave: Button = findViewById(R.id.btn_save_settings)
 		
 		// Pre-fill current values
@@ -36,6 +38,14 @@ class SettingsActivity : AppCompatActivity() {
 		swAutoStart.isChecked = settings.autoStartOnBoot
 		swPowerSaving.isChecked = settings.powerSavingModeEnabled
 		swAdaptive.isChecked = settings.adaptivePerformanceEnabled
+		swAutoMusic.isChecked = settings.autoMusicModeEnabled
+		
+		// Disable manual input when auto mode is enabled (visual hint)
+		fun updateSegmentDurationEnabled() {
+			etSegmentDuration.isEnabled = !swAutoMusic.isChecked
+		}
+		swAutoMusic.setOnCheckedChangeListener { _, _ -> updateSegmentDurationEnabled() }
+		updateSegmentDurationEnabled()
 		
 		btnSave.setOnClickListener {
 			settings.segmentDurationSeconds = etSegmentDuration.text.toString().toIntOrNull() ?: settings.segmentDurationSeconds
@@ -46,6 +56,7 @@ class SettingsActivity : AppCompatActivity() {
 			swAutoStart.isChecked.also { settings.autoStartOnBoot = it }
 			swPowerSaving.isChecked.also { settings.powerSavingModeEnabled = it }
 			swAdaptive.isChecked.also { settings.adaptivePerformanceEnabled = it }
+			swAutoMusic.isChecked.also { settings.autoMusicModeEnabled = it }
 			
 			// Notify running service to apply new settings
 			ListenForegroundService.applyUpdatedSettings(this)

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -27,6 +27,23 @@
             android:layout_height="wrap_content"
             android:inputType="number" />
 
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Auto music mode (split on silence around 2 min)" />
+            <Switch
+                android:id="@+id/sw_auto_music"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+        </LinearLayout>
+
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"


### PR DESCRIPTION
Add 'Auto music mode' to segment audio recordings by detecting silence after a target duration, preventing song interruptions.

---
<a href="https://cursor.com/background-agent?bcId=bc-57e2f358-8810-48a2-b1a7-1c89ff6c5d25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-57e2f358-8810-48a2-b1a7-1c89ff6c5d25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

